### PR TITLE
Several cleanups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ jobs:
       script:
         - docker build -t energyplus:latest --build-arg ENERGYPLUS_VERSION=$ENERGYPLUS_VERSION --build-arg ENERGYPLUS_SHA=$ENERGYPLUS_SHA --build-arg ENERGYPLUS_INSTALL_VERSION=$ENERGYPLUS_INSTALL_VERSION .
         - docker run -it energyplus:latest EnergyPlus --version
-        # Run model via ruby script using system gems
-        - docker run -it --rm -v $(pwd)/test:/var/simdata/energyplus energyplus:latest /bin/bash -c "cp /usr/local/bin/Energy+.idd /var/simdata/energyplus; cd /var/simdata/energyplus && EnergyPlus"
+        - docker run -it --rm energyplus:latest /bin/bash -c "cd /var/simdata/energyplus && EnergyPlus -D ../1ZoneUncontrolled.idf"
+        - docker run -it --rm energyplus:latest /bin/bash -c "cd /var/simdata/energyplus && EnergyPlus -D ../PythonPluginCustomOutputVariable.idf"
       after_success:
         - ./deploy_docker.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,9 @@ ENV ENERGYPLUS_INSTALL_VERSION=$ENERGYPLUS_INSTALL_VERSION
 # Downloading from Github
 # e.g. https://github.com/NREL/EnergyPlus/releases/download/v8.3.0/EnergyPlus-8.3.0-6d97d074ea-Linux-x86_64.sh
 ENV ENERGYPLUS_DOWNLOAD_BASE_URL https://github.com/NREL/EnergyPlus/releases/download/$ENERGYPLUS_TAG
-ENV ENERGYPLUS_DOWNLOAD_FILENAME EnergyPlus-$ENERGYPLUS_VERSION-$ENERGYPLUS_SHA-Linux-Ubuntu18.04-x86_64.sh
+ENV ENERGYPLUS_DOWNLOAD_BASENAME EnergyPlus-$ENERGYPLUS_VERSION-$ENERGYPLUS_SHA-Linux-Ubuntu18.04-x86_64
+ENV ENERGYPLUS_DOWNLOAD_FILENAME $ENERGYPLUS_DOWNLOAD_BASENAME.tar.gz
 ENV ENERGYPLUS_DOWNLOAD_URL $ENERGYPLUS_DOWNLOAD_BASE_URL/$ENERGYPLUS_DOWNLOAD_FILENAME
-
 
 # Collapse the update of packages, download and installation into one command
 # to make the container smaller & remove a bunch of the auxiliary apps/files
@@ -27,23 +27,17 @@ ENV ENERGYPLUS_DOWNLOAD_URL $ENERGYPLUS_DOWNLOAD_BASE_URL/$ENERGYPLUS_DOWNLOAD_F
 RUN apt-get update && apt-get install -y ca-certificates curl libx11-6 libexpat1\
     && rm -rf /var/lib/apt/lists/* \
     && curl -SLO $ENERGYPLUS_DOWNLOAD_URL \
-    && chmod +x $ENERGYPLUS_DOWNLOAD_FILENAME \
-    && echo "y\r" | ./$ENERGYPLUS_DOWNLOAD_FILENAME \
+    && tar -zxvf $ENERGYPLUS_DOWNLOAD_FILENAME \
     && rm $ENERGYPLUS_DOWNLOAD_FILENAME \
-    && cd /usr/local/EnergyPlus-$ENERGYPLUS_INSTALL_VERSION \
+    && cd $ENERGYPLUS_DOWNLOAD_BASENAME \
+    && ln -s energyplus EnergyPlus \
+    && mkdir -p /var/simdata/energyplus \
+    && cp ExampleFiles/1ZoneUncontrolled.idf /var/simdata \
+    && cp ExampleFiles/PythonPluginCustomOutputVariable.idf /var/simdata \
+    && cp ExampleFiles/PythonPluginCustomOutputVariable.py /var/simdata \
     && rm -rf DataSets Documentation ExampleFiles WeatherData MacroDataSets PostProcess/convertESOMTRpgm \
     PostProcess/EP-Compare PreProcess/FMUParser PreProcess/ParametricPreProcessor PreProcess/IDFVersionUpdater
 
-# Remove the broken symlinks
-RUN cd /usr/local/bin \
-    && find -L . -type l -delete
-
-# Add in the test files
-ADD test /usr/local/EnergyPlus-$ENERGYPLUS_INSTALL_VERSION/test_run
-RUN cp /usr/local/EnergyPlus-$ENERGYPLUS_INSTALL_VERSION/Energy+.idd \
-        /usr/local/EnergyPlus-$ENERGYPLUS_INSTALL_VERSION/test_run/
-
-VOLUME /var/simdata/energyplus
-WORKDIR /var/simdata/energyplus
+ENV PATH="/${ENERGYPLUS_DOWNLOAD_BASENAME}:${PATH}"
 
 CMD [ "/bin/bash" ]


### PR DESCRIPTION
- Fixes #13: Downloads a tarball of EnergyPlus rather than the shell script installer
  - This required adding the tarball extracted directory to PATH manually, since the installer would've put the binary symlinks in /usr/local/bin or whatever
  - I manually symlinked `energyplus` to `EnergyPlus` for backward compatability
- Fixes #14: Grabs a couple example files before deleted the `ExampleFiles` directory so that we don't have to manually keep a file around in the repo.
  - Could add more examples to run if we wanted, also we could grab an EPW if we wanted to run a full annual simulation; either way we don't need to keep the files in the github repo and manually update them
- Fixes #15: Discard the IDD copying process, EnergyPlus does not need that anymore at run time.