### PR TITLE
Optional Ubuntu 20.04 builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,15 +4,18 @@ ARG ENERGYPLUS_VERSION
 ARG ENERGYPLUS_SHA
 ARG ENERGYPLUS_INSTALL_VERSION
 ARG ENERGYPLUS_TAG
+ARG UBUNTU_BASE=18.04
 
-FROM ubuntu:18.04 AS base
+FROM ubuntu:$UBUNTU_BASE AS base
 
-MAINTAINER Nicholas Long nicholas.long@nrel.gov
+LABEL org.opencontainers.image.authors="Nicholas Long <Nicholas.Long@nrel.gov>"
 
 ARG ENERGYPLUS_VERSION
 ARG ENERGYPLUS_SHA
 ARG ENERGYPLUS_INSTALL_VERSION
 ARG ENERGYPLUS_TAG
+ARG UBUNTU_BASE
+
 ENV ENERGYPLUS_VERSION=$ENERGYPLUS_VERSION
 ENV ENERGYPLUS_TAG=$ENERGYPLUS_TAG
 ENV ENERGYPLUS_SHA=$ENERGYPLUS_SHA
@@ -20,10 +23,10 @@ ENV ENERGYPLUS_SHA=$ENERGYPLUS_SHA
 # This should be x.y.z, but EnergyPlus convention is x-y-z
 ENV ENERGYPLUS_INSTALL_VERSION=$ENERGYPLUS_INSTALL_VERSION
 
-# Downloading from Github
-# e.g. https://github.com/NREL/EnergyPlus/releases/download/v8.3.0/EnergyPlus-8.3.0-6d97d074ea-Linux-x86_64.sh
+# Downloading from GitHub
+# e.g. https://github.com/NREL/EnergyPlus/releases/download/v22.1.0/EnergyPlus-22.1.0-ed759b17ee-Linux-Ubuntu20.04-x86_64.tar.gz
 ENV ENERGYPLUS_DOWNLOAD_BASE_URL https://github.com/NREL/EnergyPlus/releases/download/$ENERGYPLUS_TAG
-ENV ENERGYPLUS_DOWNLOAD_BASENAME EnergyPlus-$ENERGYPLUS_VERSION-$ENERGYPLUS_SHA-Linux-Ubuntu18.04-x86_64
+ENV ENERGYPLUS_DOWNLOAD_BASENAME EnergyPlus-$ENERGYPLUS_VERSION-$ENERGYPLUS_SHA-Linux-Ubuntu$UBUNTU_BASE-x86_64
 ENV ENERGYPLUS_DOWNLOAD_FILENAME $ENERGYPLUS_DOWNLOAD_BASENAME.tar.gz
 ENV ENERGYPLUS_DOWNLOAD_URL $ENERGYPLUS_DOWNLOAD_BASE_URL/$ENERGYPLUS_DOWNLOAD_FILENAME
 
@@ -32,6 +35,7 @@ ENV SIMDATA_DIR=/var/simdata
 # Download
 RUN apt-get update \
     && apt-get install -y ca-certificates curl libx11-6 libexpat1 python3 python3-pip \
+    && rm -rf /var/lib/apt/lists/* \
     && curl -SLO $ENERGYPLUS_DOWNLOAD_URL
 
 # Unzip
@@ -40,7 +44,7 @@ RUN tar -zxvf $ENERGYPLUS_DOWNLOAD_FILENAME \
     && chmod +x energyplus \
     && ln -s energyplus EnergyPlus
 
-RUN mkdir -p  $SIMDATA_DIR/energyplus \
+RUN mkdir -p $SIMDATA_DIR/energyplus \
     && cd $ENERGYPLUS_DOWNLOAD_BASENAME \
     && cp ExampleFiles/1ZoneUncontrolled.idf $SIMDATA_DIR \
     && cp ExampleFiles/PythonPluginCustomOutputVariable.idf $SIMDATA_DIR \
@@ -53,13 +57,15 @@ RUN rm ${ENERGYPLUS_DOWNLOAD_BASENAME}.tar.gz \
     PostProcess/EP-Compare PreProcess/FMUParser PreProcess/ParametricPreProcessor PreProcess/IDFVersionUpdater
 
 # Use Multi-stage build to produce a smaller final image
-FROM ubuntu:18.04 AS runtime
+FROM ubuntu:$UBUNTU_BASE AS runtime
 
 ARG ENERGYPLUS_VERSION
 ARG ENERGYPLUS_SHA
+ARG UBUNTU_BASE
+
 ENV ENERGYPLUS_VERSION=$ENERGYPLUS_VERSION
 ENV ENERGYPLUS_SHA=$ENERGYPLUS_SHA
-ENV ENERGYPLUS_DOWNLOAD_BASENAME EnergyPlus-$ENERGYPLUS_VERSION-$ENERGYPLUS_SHA-Linux-Ubuntu18.04-x86_64
+ENV ENERGYPLUS_DOWNLOAD_BASENAME EnergyPlus-$ENERGYPLUS_VERSION-$ENERGYPLUS_SHA-Linux-Ubuntu$UBUNTU_BASE-x86_64
 ENV SIMDATA_DIR=/var/simdata
 
 COPY --from=base $ENERGYPLUS_DOWNLOAD_BASENAME $ENERGYPLUS_DOWNLOAD_BASENAME
@@ -67,17 +73,15 @@ COPY --from=base $SIMDATA_DIR $SIMDATA_DIR
 
 # Copy shared libraries required to run energyplus
 COPY --from=base \
-    /usr/lib/x86_64-linux-gnu/libX11.so.1* \
-    /usr/lib/x86_64-linux-gnu/libX11.so.6* \
-    /usr/lib/x86_64-linux-gnu/libxcb.so.1* \
-    /usr/lib/x86_64-linux-gnu/libXau.so.6* \
-    /usr/lib/x86_64-linux-gnu/libXau.so.6* \
-    /usr/lib/x86_64-linux-gnu/libXdmcp.so.6* \
-    /usr/lib/x86_64-linux-gnu/libgomp.so.1* \
+    /usr/lib/x86_64-linux-gnu/libX11.so* \
+    /usr/lib/x86_64-linux-gnu/libxcb.so* \
+    /usr/lib/x86_64-linux-gnu/libXau.so* \
+    /usr/lib/x86_64-linux-gnu/libXdmcp.so* \
+    /usr/lib/x86_64-linux-gnu/libgomp.so* \
     /usr/lib/x86_64-linux-gnu/
 COPY --from=base \
-    /lib/x86_64-linux-gnu/libbsd.so.0* \
-    /lib/x86_64-linux-gnu/libexpat.so.1* \
+    /lib/x86_64-linux-gnu/libbsd.so* \
+    /lib/x86_64-linux-gnu/libexpat.so* \
     /lib/x86_64-linux-gnu/
 
 # Add energyplus to PATH so can run "energyplus" in any directory

--- a/README.md
+++ b/README.md
@@ -10,18 +10,18 @@ This project has multiple versions of EnergyPlus ready for use in a single conta
 
 Below is a table of the various docker tags and their meanings as seen on [this page](https://hub.docker.com/r/nrel/energyplus/tags/).
 
-| Tag     | Description                                                                             |
-|---------|-----------------------------------------------------------------------------------------|
-| x.y.z   | Build of official EnergyPlus release (recommended use)                                  |
-| latest  | Latest official release of EnergyPlus (e.g. 2.5.1)                                      |
-| develop | Release of [develop branch](https://github.com/NREL/docker-energyplus/tree/develop)     |
+| Tag     | Description                                                                         |
+|---------|-------------------------------------------------------------------------------------|
+| x.y.z   | Build of official EnergyPlus release (recommended use)                              |
+| latest  | Latest official release of EnergyPlus (e.g. 22.1.0)                                 |
+| develop | Release of [develop branch](https://github.com/NREL/docker-energyplus/tree/develop) |
 
 ## Building EnergyPlus Container
 
-To build the EnergyPlus docker image locally, see the following example command for v9.5.0.
+To build the EnergyPlus docker image locally, see the following example command for v22.1.0 using Ubuntu 20.04 as the base image.
 
 ```
-docker build --target base -t energyplus --build-arg ENERGYPLUS_VERSION=9.6.0 --build-arg ENERGYPLUS_SHA=4b123cf80f --build-arg ENERGYPLUS_INSTALL_VERSION=9-6-0 --build-arg ENERGYPLUS_TAG=v9.6.0_PlusSpaceFix1 .
+docker build -t energyplus --build-arg ENERGYPLUS_VERSION=22.1.0 --build-arg ENERGYPLUS_SHA=ed759b17ee --build-arg ENERGYPLUS_INSTALL_VERSION=22-1-0 --build-arg ENERGYPLUS_TAG=v22.1.0 --build-arg UBUNTU_BASE=20.04 .
 ```
 
 ## Example


### PR DESCRIPTION
This PR updates the Dockerfile to default to 18.04 base images, with an optional `UBUNTU_BASE` argument for 20.04.

Currently everything works except for the very last COPY line, and I don't know why because the files definitely exist there in the base target:
```
COPY --from=base \
    /lib/x86_64-linux-gnu/libbsd.so* \
    /lib/x86_64-linux-gnu/libexpat.so* \
    /lib/x86_64-linux-gnu/
```